### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/brigade/db-query-matchers'
   spec.license       = 'MIT'
 
-  s.metadata = {
+  spec.metadata = {
     'changelog_uri' => 'https://github.com/sds/db-query-matchers/blob/main/CHANGELOG.md'
   }
 

--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/brigade/db-query-matchers'
   spec.license       = 'MIT'
 
+  s.metadata = {
+    'changelog_uri' => 'https://github.com/sds/db-query-matchers/blob/main/CHANGELOG.md'
+  }
+
   spec.files         = Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater