### PR TITLE
Cut version 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0
+
+- Drop support for Ruby 3.0 (3.1+ still supported)
+
 ## 0.12.0
 
 - Drop support for EOL software (Ruby 2.x, Rails 6.0)

--- a/lib/db_query_matchers/version.rb
+++ b/lib/db_query_matchers/version.rb
@@ -1,4 +1,4 @@
 # Defines the gem version.
 module DBQueryMatchers
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end


### PR DESCRIPTION
Drop support for Ruby 3.0 (3.1+ still supported)
